### PR TITLE
Release v0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@silexlabs/silex-desktop",
-  "version": "0.1.1-canary.3",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@silexlabs/silex-desktop",
-      "version": "0.1.1-canary.3",
+      "version": "0.1.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tauri-apps/api": "^2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silexlabs/silex-desktop",
-  "version": "0.1.1-canary.3",
+  "version": "0.1.1",
   "description": "Silex website builder - desktop app powered by Tauri",
   "license": "GPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
Release v0.1.1 — bump commit already published on npm and referenced by silex-meta v3.7.3.

This PR aligns `main` with the released state.